### PR TITLE
fix(toc): links are now clickable and no more wrong page numbers

### DIFF
--- a/src/services/Pdf.ts
+++ b/src/services/Pdf.ts
@@ -1,8 +1,7 @@
 import { Browser, Page, PDFOptions } from 'puppeteer'
-import handlebars from 'handlebars'
 import { PdfOptions, pdfOptionsFactory } from './PdfOptions'
 import { enhanceContent } from '../util'
-import { mergePDFs, extractPDFToc } from '../util/pdf'
+import { extractPDFToc } from '../util/pdf'
 
 export const PAPER_FORMATS = ['A3', 'A4', 'A5', 'Legal', 'Letter', 'Tabloid']
 export const PAGE_ORIENTATIONS = ['portrait', 'landscape']

--- a/src/services/Pdf.ts
+++ b/src/services/Pdf.ts
@@ -30,7 +30,7 @@ export class Pdf {
   }
 
   private static async generateContent(options: PdfOptions, page: Page): Promise<Buffer> {
-    await page.setContent(options.content, { waitUntil: 'networkidle2' })
+    await page.setContent(options.content, { waitUntil: 'networkidle0' })
     const pdfOptions = Pdf.buildPdfArguments(options, false)
     return await page.pdf(pdfOptions)
   }
@@ -38,11 +38,9 @@ export class Pdf {
   private static async generateToc(pdfBuffer: Buffer, options: PdfOptions, page: Page): Promise<Buffer> {
     if (options.tocTemplate) {
       await extractPDFToc(pdfBuffer, options)
-      const tocTemplate = handlebars.compile(options.tocTemplate)(options.tocContext)
-      await page.setContent(tocTemplate)
-      const pdfOptions = Pdf.buildPdfArguments(options, true)
-      const tocPdfBuffer = await page.pdf(pdfOptions)
-      return await mergePDFs(pdfBuffer, tocPdfBuffer)
+      await page.setContent(options.content, { waitUntil: 'networkidle0' })
+      const pdfOptions = Pdf.buildPdfArguments(options, false)
+      return await page.pdf(pdfOptions)
     }
 
     return pdfBuffer

--- a/src/services/__test__/Pdf.spec.ts
+++ b/src/services/__test__/Pdf.spec.ts
@@ -65,4 +65,18 @@ describe('Pdf', () => {
   it('generates landscape pdf', async () => {
     await testPdfParam({ orientation: 'landscape' }, { landscape: true })
   })
+
+  it('generates toc when .print-toc template is available', async () => {
+    const mockedPuppeteer = mocked(puppeteer)
+    const browser = await mockedPuppeteer.launch()
+    const pdf = new Pdf(browser)
+    await pdf.generate(
+      pdfOptionsFactory({
+        content: `
+        <div class="print-toc"></div>
+        <h2 id="myId">Hello {{ name }}</h2>`,
+        context: { name: 'Express PDF Generator' },
+      })
+    )
+  })
 })

--- a/src/util/__test__/index.spec.ts
+++ b/src/util/__test__/index.spec.ts
@@ -74,4 +74,13 @@ describe('prepareToc from src/utils.ts', () => {
     expect(options.content).toMatch(/<h5 class="toc-ignore"><\/h5>/)
     expect(options.content).toMatch(/<h6 class="toc-ignore"><\/h6>/)
   })
+
+  it('should insert an element with removeAfterTocExtraction and heading id as its contents', function () {
+    const content = '<div class="print-toc"></div><h1 id="hel1">hello</h1><h2>hello2</h2>'
+    const options = pdfOptionsFactory({ content })
+    prepareToc(options)
+    options.tocContext._toc.forEach((data) =>
+      expect(options.content).toContain(`class="removeAfterTocExtraction">${data.id}<`)
+    )
+  })
 })

--- a/src/util/__test__/pdf.spec.ts
+++ b/src/util/__test__/pdf.spec.ts
@@ -6,12 +6,17 @@ import { extractPDFToc, mergePDFs } from '../pdf'
 describe('/src/util/pdf.ts', () => {
   it('should extract page numbers for TOCs', async () => {
     const options = pdfOptionsFactory({
-      content: '<p></p>',
+      content: `
+        <div class="print-toc"></div>
+        <h1 id="1">Page 1<span class="removeAfterTocExtraction">Page 1</span></h1>
+        <h1 id="2">Page 2<span class="removeAfterTocExtraction">Page 2</span></h1>
+        <h1 id="3">Page 3<span class="removeAfterTocExtraction">Page 3</span></h1>
+      `,
       tocContext: {
         _toc: [
-          { id: '', title: 'Page 1', href: '', level: 1 },
-          { id: '', title: 'Page 2', href: '', level: 1 },
-          { id: '', title: 'Page 3', href: '', level: 1 },
+          { id: 'Page 1', title: 'Page 1', href: '', level: 1 },
+          { id: 'Page 2', title: 'Page 2', href: '', level: 1 },
+          { id: 'Page 3', title: 'Page 3', href: '', level: 1 },
         ],
       },
     })
@@ -23,6 +28,9 @@ describe('/src/util/pdf.ts', () => {
       expect.objectContaining({ page: 2 }),
       expect.objectContaining({ page: 3 }),
     ])
+    expect(options.content).not.toContain('<span class="removeAfterTocExtraction">Page 1</span>')
+    expect(options.content).not.toContain('<span class="removeAfterTocExtraction">Page 2</span>')
+    expect(options.content).not.toContain('<span class="removeAfterTocExtraction">Page 3</span>')
   })
   it('should merge two PDF files', async () => {
     const pdfBuffer = fs.readFileSync(path.join(__dirname, '/sample.pdf'))

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -40,7 +40,6 @@ export function prepareToc(options: PdfOptions): void {
 
     bodyEl.innerHTML = tocElement.outerHTML
     options.tocTemplate = tocDocument.documentElement.outerHTML
-    options.content = document.documentElement.outerHTML
 
     document.querySelectorAll(headingSelectors).forEach((h) => {
       if (h.classList.contains(tocIgnoreClass)) return
@@ -49,10 +48,12 @@ export function prepareToc(options: PdfOptions): void {
         const id = h.id || UID.sync(16)
         const level = Number.parseInt(h.tagName.substr(1))
         h.id = id
+        h.innerHTML = `${title}<span class="removeAfterTocExtraction">${id}</span>`
         options.tocContext._toc.push({ id, title, level, href: `#${id}` })
       }
     })
   }
+  options.content = document.documentElement.outerHTML
 }
 
 export async function enhanceContent(options: PdfOptions): Promise<void> {

--- a/src/util/pdf.ts
+++ b/src/util/pdf.ts
@@ -1,6 +1,8 @@
 import parsePdf from 'pdf-parse'
 import { PdfOptions } from '../services/PdfOptions'
 import { PDFDocument } from 'pdf-lib'
+import { JSDOM } from 'jsdom'
+import * as handlebars from 'handlebars'
 
 const PAGE_BREAK_MARKER = '\n------page-break------'
 
@@ -32,12 +34,24 @@ export const extractPDFToc = async (pdfBuffer: Buffer, options: PdfOptions): Pro
   const data = await parsePdf(pdfBuffer, { pagerender: pageRender })
   data.text.split(PAGE_BREAK_MARKER).forEach((content: string, pageIndex: number) => {
     options.tocContext._toc.map((entry) => {
-      if (content.includes(entry.title)) {
+      if (content.includes(entry.id)) {
         entry.page = pageIndex + 1
       }
       return entry
     })
   })
+
+  const document = new JSDOM(options.content).window.document
+  const tocElement: HTMLElement | null = document.querySelector('.print-toc')
+  document.querySelectorAll('.removeAfterTocExtraction').forEach((el) => el.parentNode?.removeChild(el))
+  if (tocElement) {
+    tocElement.innerHTML = handlebars.compile(options.tocTemplate || '')({
+      ...options.context,
+      ...options.tocContext,
+    })
+    options.tocTemplate = tocElement.outerHTML
+    options.content = document.documentElement.outerHTML
+  }
 }
 
 export async function mergePDFs(document: Buffer, toc: Buffer): Promise<Buffer> {

--- a/src/util/pdf.ts
+++ b/src/util/pdf.ts
@@ -50,8 +50,8 @@ export const extractPDFToc = async (pdfBuffer: Buffer, options: PdfOptions): Pro
       ...options.tocContext,
     })
     options.tocTemplate = tocElement.outerHTML
-    options.content = document.documentElement.outerHTML
   }
+  options.content = document.documentElement.outerHTML
 }
 
 export async function mergePDFs(document: Buffer, toc: Buffer): Promise<Buffer> {


### PR DESCRIPTION
* Renders the whole PDF twice to make items on the table of contents clickable. It introduces some performance issues but makes the final PDF more accessible and usable.
* Reading page numbers are now based on the heading tag UID instead of the text itself to avoid chapters pointing to a wrong page number.