### PR TITLE
fix: fix incorrect totalPages template

### DIFF
--- a/src/util/__test__/index.spec.ts
+++ b/src/util/__test__/index.spec.ts
@@ -27,10 +27,10 @@ describe('utils.ts', () => {
 
     expect(options.displayHeaderFooter).toBeTruthy()
     expect(options.header).toBe(
-      `<div style="margin: 0 1.9cm 0 1.9cm; font-size: 8px"><span class="pageNumber"></span> <span class="pageNumber"></span> <span class="date"></span> <span class="title"></span> <span class="url"></span></div>`
+      `<div style="margin: 0 1.9cm 0 1.9cm; font-size: 8px"><span class="pageNumber"></span> <span class="totalPages"></span> <span class="date"></span> <span class="title"></span> <span class="url"></span></div>`
     )
     expect(options.footer).toBe(
-      `<div style="margin: 0 1.9cm 0 1.9cm; font-size: 8px"><span class="pageNumber"></span> <span class="pageNumber"></span> <span class="date"></span> <span class="title"></span> <span class="url"></span></div>`
+      `<div style="margin: 0 1.9cm 0 1.9cm; font-size: 8px"><span class="pageNumber"></span> <span class="totalPages"></span> <span class="date"></span> <span class="title"></span> <span class="url"></span></div>`
     )
   })
 })

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -18,7 +18,7 @@ export function compileHeaderOrFooterTemplate(template: TemplateType, options: P
     title: '<span class="title"></span>',
     url: '<span class="url"></span>',
     pageNumber: '<span class="pageNumber"></span>',
-    totalPages: '<span class="pageNumber"></span>',
+    totalPages: '<span class="totalPages"></span>',
   }
   return handlebars.compile(printTemplate)(context)
 }


### PR DESCRIPTION
# Steps to reproduce
1. Run `pdf-generator-service`
```bash
yarn install
yarn build
yarn start
```
2. Generate PDF with following options
```json
{
 "content": "<h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1><h1>A</h1>",
 "context": {},
 "orientation": "portrait",
 "format": "A4",
 "header": "<p>Page {{{pageNumber}}} of {{{totalPages}}}</p>",
 "footer": "<p>Something interesting here...</p>"
}
```

# Expected
Header of page 1 will be "Page 1 of 2"

# Happened
Header of page 1 is "Page 1 of 1"

# Fix
- Incorrect template for `totalPages` at `utils/index.ts` on line 21
  - change template to `<span class="totalPages"></span>`